### PR TITLE
Nissix plugin scope-packages on no-hadron-app

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 const path = require('path');
-const bootstrap = require('wix-bootstrap-ng');
+const bootstrap = require('@wix/wix-bootstrap-ng');
 
 console.log('yo');
 const src = process.env.SRC_PATH || path.join('.', 'dist', 'src');
 const server = path.join(src, 'server');
 
 bootstrap()
-  .use(require('wix-bootstrap-greynode'))
-  .use(require('wix-bootstrap-hadron'))
-  .use(require('wix-bootstrap-renderer'))
+  .use(require('@wix/wix-bootstrap-greynode'))
+  .use(require('@wix/wix-bootstrap-hadron'))
+  .use(require('@wix/wix-bootstrap-renderer'))
   .express(server)
   .start({ disableCluster: process.env.NODE_ENV === 'development' });

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "lint-staged": "^7.2.2",
     "jest-yoshi-preset": "^3.5.0",
     "puppeteer": "^1.1.0",
-    "wix-bootstrap-testkit": "latest",
-    "wix-config-emitter": "latest",
-    "yoshi": "^3.0.0",
+    "@wix/wix-bootstrap-testkit": "latest",
+    "@wix/wix-config-emitter": "latest",
+    "@wix/yoshi": "^3.0.0",
     "yoshi-style-dependencies": "^3.0.0"
   },
   "dependencies": {
@@ -34,15 +34,15 @@
     "react-dom": "15.6.1",
     "react-i18next": "^7.11.0",
     "regenerator-runtime": "^0.11.0",
-    "wix-axios-config": "latest",
-    "wix-bootstrap-greynode": "^1.0.822",
-    "wix-bootstrap-hadron": "^1.0.28",
-    "wix-bootstrap-ng": "latest",
-    "wix-bootstrap-renderer": "^1.0.5",
-    "wix-express-csrf": "latest",
-    "wix-express-rendering-model": "^1.0.787",
-    "wix-express-require-https": "latest",
-    "wix-renderer": "^1.0.929"
+    "@wix/wix-axios-config": "latest",
+    "@wix/wix-bootstrap-greynode": "^1.0.822",
+    "@wix/wix-bootstrap-hadron": "^1.0.28",
+    "@wix/wix-bootstrap-ng": "latest",
+    "@wix/wix-bootstrap-renderer": "^1.0.5",
+    "@wix/wix-express-csrf": "latest",
+    "@wix/wix-express-rendering-model": "^1.0.787",
+    "@wix/wix-express-require-https": "latest",
+    "@wix/wix-renderer": "^1.0.929"
   },
   "jest": {
     "preset": "jest-yoshi-preset"

--- a/src/client.js
+++ b/src/client.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { I18nextProvider } from 'react-i18next';
 import axios from 'axios';
-import { wixAxiosConfig } from 'wix-axios-config';
+import { wixAxiosConfig } from '@wix/wix-axios-config';
 import i18n from './i18n';
 import App from './components/App';
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,8 @@
 import 'regenerator-runtime/runtime';
-import wixExpressCsrf from 'wix-express-csrf';
-import wixExpressRequireHttps from 'wix-express-require-https';
-import wixExpressRenderingModel from 'wix-express-rendering-model';
-import wixRenderer from 'wix-renderer';
+import wixExpressCsrf from '@wix/wix-express-csrf';
+import wixExpressRequireHttps from '@wix/wix-express-require-https';
+import wixExpressRenderingModel from '@wix/wix-express-rendering-model';
+import wixRenderer from '@wix/wix-renderer';
 const wixRunMode = require('wix-run-mode');
 const path = require('path');
 

--- a/test/environment.js
+++ b/test/environment.js
@@ -1,5 +1,5 @@
-import testkit from 'wix-bootstrap-testkit';
-import configEmitter from 'wix-config-emitter';
+import testkit from '@wix/wix-bootstrap-testkit';
+import configEmitter from '@wix/wix-config-emitter';
 
 export const app = bootstrapServer();
 

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-mocha');
+module.exports = require('@wix/yoshi/config/wallaby-mocha');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.423s



Output Log:
Migrating package "no-hadron-app" in .


## Migration from non scope to @wix/scoped packages
> /tmp/ea3380417f463618605a4e8397fb7e18

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
index.js
wallaby.js
src/client.js
src/server.js
test/environment.js
```

